### PR TITLE
refactor: export discard event to be used by third party plugins and make aws credential optional for workload identity support

### DIFF
--- a/entities/errors.go
+++ b/entities/errors.go
@@ -1,0 +1,20 @@
+// Copyright Mia srl
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package entities
+
+import "errors"
+
+var ErrDiscardEvent = errors.New("event discarded")

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/mia-platform/integration-connector-agent/entities"
 	"github.com/mia-platform/integration-connector-agent/internal/processors"
-	"github.com/mia-platform/integration-connector-agent/internal/processors/filter"
 	"github.com/mia-platform/integration-connector-agent/internal/sinks"
 	"github.com/mia-platform/integration-connector-agent/internal/utils"
 
@@ -74,7 +73,7 @@ loop:
 
 			processedMessage, err := p.processors.Process(ctx, message)
 			if err != nil {
-				if errors.Is(err, filter.ErrEventToFilter) {
+				if errors.Is(err, entities.ErrDiscardEvent) {
 					// the message has been filtered out
 					p.logger.WithError(err).WithField("message", message.Data()).Trace("event filtered for pipeline")
 					continue

--- a/internal/processors/filter/filter.go
+++ b/internal/processors/filter/filter.go
@@ -24,10 +24,6 @@ import (
 	"github.com/google/cel-go/common/types"
 )
 
-var (
-	ErrEventToFilter = fmt.Errorf("event is to filter")
-)
-
 type Filter struct {
 	program cel.Program
 }
@@ -47,7 +43,7 @@ func (m Filter) Process(input entities.PipelineEvent) (entities.PipelineEvent, e
 		return nil, fmt.Errorf("program evaluation failed: %s", err.Error())
 	}
 	if out.Equal(types.False) == types.True {
-		return nil, ErrEventToFilter
+		return nil, entities.ErrDiscardEvent
 	}
 	return input, nil
 }

--- a/internal/processors/filter/filter_test.go
+++ b/internal/processors/filter/filter_test.go
@@ -76,7 +76,7 @@ func TestFilter(t *testing.T) {
 				OriginalRaw: []byte(`{"type":"event-type"}`),
 			},
 
-			expectedResultError: ErrEventToFilter.Error(),
+			expectedResultError: entities.ErrDiscardEvent.Error(),
 		},
 		"check on multiple event type": {
 			config: Config{
@@ -101,7 +101,7 @@ func TestFilter(t *testing.T) {
 				OriginalRaw: []byte(`{"type":"event-to-filter"}`),
 			},
 
-			expectedResultError: ErrEventToFilter.Error(),
+			expectedResultError: entities.ErrDiscardEvent.Error(),
 		},
 		"check on event content": {
 			config: Config{
@@ -126,7 +126,7 @@ func TestFilter(t *testing.T) {
 				OriginalRaw: []byte(`{"type":"event-type","fields":{"id": "my-id"}}`),
 			},
 
-			expectedResultError: ErrEventToFilter.Error(),
+			expectedResultError: entities.ErrDiscardEvent.Error(),
 		},
 		"not an expression": {
 			config: Config{

--- a/internal/processors/processor_test.go
+++ b/internal/processors/processor_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/mia-platform/integration-connector-agent/entities"
 	"github.com/mia-platform/integration-connector-agent/internal/config"
-	"github.com/mia-platform/integration-connector-agent/internal/processors/filter"
 	"github.com/sirupsen/logrus/hooks/test"
 
 	"github.com/stretchr/testify/require"
@@ -71,7 +70,7 @@ func TestProcessors_Process(t *testing.T) {
 			processors: []entities.Processor{
 				&mockProcessor{
 					processFunc: func(event entities.PipelineEvent) (entities.PipelineEvent, error) {
-						return event, fmt.Errorf("%w: event filtered", filter.ErrEventToFilter)
+						return event, fmt.Errorf("%w: event filtered", entities.ErrDiscardEvent)
 					},
 				},
 				&mockProcessor{
@@ -81,7 +80,7 @@ func TestProcessors_Process(t *testing.T) {
 				},
 			},
 			input:       &entities.Event{OriginalRaw: []byte("test")},
-			expectedErr: fmt.Sprintf("%s: event filtered", filter.ErrEventToFilter),
+			expectedErr: fmt.Sprintf("%s: event filtered", entities.ErrDiscardEvent),
 		},
 	}
 

--- a/internal/sources/aws-sqs/config.go
+++ b/internal/sources/aws-sqs/config.go
@@ -34,6 +34,10 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("queueId must be provided")
 	}
 
+	if c.Region == "" {
+		return fmt.Errorf("region must be provided")
+	}
+
 	if c.AccessKeyID == "" {
 		return fmt.Errorf("accessKeyId must be provided")
 	}

--- a/internal/sources/aws-sqs/config.go
+++ b/internal/sources/aws-sqs/config.go
@@ -34,16 +34,5 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("queueId must be provided")
 	}
 
-	if c.Region == "" {
-		return fmt.Errorf("region must be provided")
-	}
-
-	if c.AccessKeyID == "" {
-		return fmt.Errorf("accessKeyId must be provided")
-	}
-	if c.SecretAccessKey == "" {
-		return fmt.Errorf("secretAccessKey must be provided")
-	}
-
 	return nil
 }

--- a/internal/sources/aws-sqs/consumer_test.go
+++ b/internal/sources/aws-sqs/consumer_test.go
@@ -46,9 +46,6 @@ func TestNew(t *testing.T) {
 			config string
 		}{
 			{config: `{"queueUrl": ""}`},
-			{config: `{"queueUrl": "a"}`},
-			{config: `{"queueUrl": "a","accessKeyId":"key"}`},
-			{config: `{"queueUrl": "a","secretAccessKey":{"fromEnv":"MISSING_ENV"}}`},
 		}
 
 		for _, tc := range testCases {

--- a/internal/sources/aws-sqs/internal/sqs.go
+++ b/internal/sources/aws-sqs/internal/sqs.go
@@ -52,14 +52,18 @@ type Config struct {
 func New(ctx context.Context, log *logrus.Logger, c Config) (SQS, error) {
 	loadOptions := make([]func(*config.LoadOptions) error, 0)
 
-	credentialOptions := config.WithCredentialsProvider(
-		credentials.NewStaticCredentialsProvider(
-			c.AccessKeyID,
-			c.SecretAccessKey,
-			c.SessionToken,
-		),
-	)
-	loadOptions = append(loadOptions, credentialOptions)
+	if c.AccessKeyID != "" && c.SecretAccessKey != "" && c.SessionToken != "" {
+		credentialOptions := config.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider(
+				c.AccessKeyID,
+				c.SecretAccessKey,
+				c.SessionToken,
+			),
+		)
+		loadOptions = append(loadOptions, credentialOptions)
+	} else {
+		log.Warn("AccessKeyID, SecretAccessKey, and SessionToken are not provided, using default credentials")
+	}
 
 	if c.Region != "" {
 		loadOptions = append(loadOptions, config.WithRegion(c.Region))


### PR DESCRIPTION
Export `ErrDiscardEvent` from entities to be used by third party plugins