### PR TITLE
feat: GCP authn support from credentials configuration

### DIFF
--- a/internal/sources/gcp-pubsub/config.go
+++ b/internal/sources/gcp-pubsub/config.go
@@ -15,13 +15,18 @@
 
 package gcppubsub
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/mia-platform/integration-connector-agent/internal/config"
+)
 
 type Config struct {
-	ProjectID          string `json:"projectId"`
-	TopicName          string `json:"topicName"`
-	SubscriptionID     string `json:"subscriptionId"`
-	AckDeadlineSeconds int    `json:"ackDeadlineSeconds,omitempty"`
+	ProjectID          string              `json:"projectId"`
+	TopicName          string              `json:"topicName"`
+	SubscriptionID     string              `json:"subscriptionId"`
+	AckDeadlineSeconds int                 `json:"ackDeadlineSeconds,omitempty"`
+	CredentialsJSON    config.SecretSource `json:"credentialsJson,omitempty"`
 }
 
 func (c *Config) Validate() error {

--- a/internal/sources/gcp-pubsub/consumer.go
+++ b/internal/sources/gcp-pubsub/consumer.go
@@ -49,6 +49,7 @@ func New(options *ConsumerOptions, cfg config.GenericConfig, pipeline pipeline.I
 		TopicName:          config.TopicName,
 		SubscriptionID:     config.SubscriptionID,
 		AckDeadlineSeconds: config.AckDeadlineSeconds,
+		CredentialsJSON:    config.CredentialsJSON.String(),
 	})
 	if err != nil {
 		return nil, err

--- a/internal/sources/gcp-pubsub/internal/pubsub.go
+++ b/internal/sources/gcp-pubsub/internal/pubsub.go
@@ -22,6 +22,7 @@ import (
 
 	"cloud.google.com/go/pubsub"
 	"github.com/sirupsen/logrus"
+	"google.golang.org/api/option"
 )
 
 type ListenerFunc func(ctx context.Context, data []byte) error
@@ -42,10 +43,17 @@ type PubSubConfig struct {
 	AckDeadlineSeconds int
 	TopicName          string
 	SubscriptionID     string
+	CredentialsJSON    string
 }
 
 func New(ctx context.Context, log *logrus.Logger, config PubSubConfig) (PubSub, error) {
-	client, err := pubsub.NewClient(ctx, config.ProjectID)
+	options := make([]option.ClientOption, 0)
+	if config.CredentialsJSON != "" {
+		log.Debug("using credentials JSON for Pub/Sub client")
+		options = append(options, option.WithCredentialsJSON([]byte(config.CredentialsJSON)))
+	}
+
+	client, err := pubsub.NewClient(ctx, config.ProjectID, options...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create pubsub client: %w", err)
 	}


### PR DESCRIPTION
This PR introduces support for the GCP Credential JSON in order to authenticate without setting up runtime context and support multiple sources on different GCP