### PR TITLE
fix: aws cloud trail event resource name extractor integrated in services

### DIFF
--- a/internal/processors/cloud-vendor-aggregator/aws/services/lambda/lambda_test.go
+++ b/internal/processors/cloud-vendor-aggregator/aws/services/lambda/lambda_test.go
@@ -118,6 +118,33 @@ func TestGetData(t *testing.T) {
 			},
 		},
 		{
+			name: "returns function name from arn resource on tag events",
+			event: &awssqsevents.CloudTrailEvent{
+				Account: "123456789012",
+				Source:  "aws.lambda",
+				Detail: awssqsevents.CloudTrailEventDetail{
+					EventSource:      "lambda.amazonaws.com",
+					AWSRegion:        "us-west-2",
+					ResponseElements: nil,
+					EventName:        "TagResource20170331v2",
+					RequestParameters: map[string]interface{}{
+						"resource": "arn:aws:lambda:eu-north-1:accountid:function:test-function",
+						"tags": map[string]string{
+							"t1": "tv2",
+						},
+					},
+				},
+			},
+			expectedAsset: &commons.Asset{
+				Name:          "test-function",
+				Type:          "lambda.amazonaws.com",
+				Location:      "us-west-2",
+				Provider:      commons.AWSAssetProvider,
+				Relationships: []string{"account/123456789012"},
+				Tags:          commons.Tags{},
+			},
+		},
+		{
 			name: "returns tags from function if available",
 			event: &awssqsevents.CloudTrailEvent{
 				Account: "123456789012",

--- a/internal/processors/cloud-vendor-aggregator/aws/services/s3/s3.go
+++ b/internal/processors/cloud-vendor-aggregator/aws/services/s3/s3.go
@@ -43,10 +43,10 @@ func (s *S3) GetData(ctx context.Context, event *awssqsevents.CloudTrailEvent) (
 	// it cannot fail because the event is already validated from the main processor
 	data, _ := json.Marshal(event)
 
-	bucketName, ok := event.Detail.RequestParameters["bucketName"].(string)
-	if !ok {
-		s.logger.Warn("bucketName not found in request parameters")
-		return nil, fmt.Errorf("%w: bucket name not found in request parameters", commons.ErrInvalidEvent)
+	bucketName, err := event.ResourceName()
+	if err != nil {
+		s.logger.WithError(err).Error("bucketName not found in request parameters")
+		return nil, fmt.Errorf("%w: %s", commons.ErrInvalidEvent, err.Error())
 	}
 
 	tags, err := s.client.GetTags(ctx, bucketName)

--- a/internal/processors/cloud-vendor-aggregator/aws/services/s3/s3_test.go
+++ b/internal/processors/cloud-vendor-aggregator/aws/services/s3/s3_test.go
@@ -39,6 +39,7 @@ func TestGetData(t *testing.T) {
 		{
 			name: "error if event is missing the bucketName in request parameters",
 			event: &awssqsevents.CloudTrailEvent{
+				Source: "aws.s3",
 				Detail: awssqsevents.CloudTrailEventDetail{
 					EventSource: "s3.amazonaws.com",
 					AWSRegion:   "us-west-2",
@@ -50,6 +51,7 @@ func TestGetData(t *testing.T) {
 			name: "returns tags retrieved from S3",
 			event: &awssqsevents.CloudTrailEvent{
 				Account: "123456789012",
+				Source:  "aws.s3",
 				Detail: awssqsevents.CloudTrailEventDetail{
 					EventSource: "s3.amazonaws.com",
 					AWSRegion:   "us-west-2",
@@ -80,6 +82,7 @@ func TestGetData(t *testing.T) {
 			name: "returns empty tags if S3 client fails",
 			event: &awssqsevents.CloudTrailEvent{
 				Account: "123456789012",
+				Source:  "aws.s3",
 				Detail: awssqsevents.CloudTrailEventDetail{
 					EventSource: "s3.amazonaws.com",
 					AWSRegion:   "us-west-2",


### PR DESCRIPTION
The CloudTrailEvent.ResourceName was not properly used in AWS services data extractors