### PR TITLE
feat: event timestamp

### DIFF
--- a/internal/processors/cloud-vendor-aggregator/aws/processor.go
+++ b/internal/processors/cloud-vendor-aggregator/aws/processor.go
@@ -56,6 +56,11 @@ func (p *Processor) Process(input entities.PipelineEvent) (entities.PipelineEven
 		return nil, fmt.Errorf("failed to unmarshal input data: %w", err)
 	}
 
+	if input.Operation() == entities.Delete {
+		p.logger.Debug("Delete operation detected, skipping event processing")
+		return input.Clone(), nil
+	}
+
 	dataProcessor, err := p.EventDataProcessor(cloudTrailEvent)
 	if err != nil {
 		p.logger.WithError(err).Error("Failed to get event data processor")

--- a/internal/processors/cloud-vendor-aggregator/aws/services/lambda/lambda.go
+++ b/internal/processors/cloud-vendor-aggregator/aws/services/lambda/lambda.go
@@ -57,17 +57,15 @@ func (l *Lambda) GetData(ctx context.Context, event *awssqsevents.CloudTrailEven
 		tags = functionDetails.Tags
 	}
 
-	lambda := &commons.Asset{
-		Name:          name,
-		Type:          event.Detail.EventSource,
-		Provider:      commons.AWSAssetProvider,
-		Location:      event.Detail.AWSRegion,
-		Tags:          tags,
-		Relationships: []string{"account/" + event.Account},
-		RawData:       data,
-	}
+	relationships := []string{"account/" + event.Account}
 
-	return json.Marshal(lambda)
+	return json.Marshal(
+		commons.NewAsset(name, event.Detail.EventSource, commons.AWSAssetProvider).
+			WithLocation(event.Detail.AWSRegion).
+			WithTags(tags).
+			WithRelationships(relationships).
+			WithRawData(data),
+	)
 }
 
 func (l *Lambda) lambdaName(event *awssqsevents.CloudTrailEvent) string {

--- a/internal/processors/cloud-vendor-aggregator/aws/services/lambda/lambda_test.go
+++ b/internal/processors/cloud-vendor-aggregator/aws/services/lambda/lambda_test.go
@@ -204,6 +204,7 @@ func TestGetData(t *testing.T) {
 				require.Equal(t, tc.expectedAsset.Location, asset.Location)
 				require.Equal(t, tc.expectedAsset.Provider, asset.Provider)
 				require.Equal(t, tc.expectedAsset.Tags, asset.Tags)
+				require.NotEmpty(t, asset.Timestamp)
 			}
 		})
 	}

--- a/internal/processors/cloud-vendor-aggregator/aws/services/s3/s3.go
+++ b/internal/processors/cloud-vendor-aggregator/aws/services/s3/s3.go
@@ -55,15 +55,14 @@ func (s *S3) GetData(ctx context.Context, event *awssqsevents.CloudTrailEvent) (
 		tags = make(commons.Tags)
 	}
 
-	bucket := &commons.Asset{
-		Name:          bucketName,
-		Type:          event.Detail.EventSource,
-		Location:      event.Detail.AWSRegion,
-		Tags:          tags,
-		Provider:      commons.AWSAssetProvider,
-		Relationships: []string{"account/" + event.Account},
-		RawData:       data,
-	}
+	relationships := []string{"account/" + event.Account}
 
-	return json.Marshal(bucket)
+	return json.Marshal(
+		commons.
+			NewAsset(bucketName, event.Detail.EventSource, commons.AWSAssetProvider).
+			WithLocation(event.Detail.AWSRegion).
+			WithTags(tags).
+			WithRelationships(relationships).
+			WithRawData(data),
+	)
 }

--- a/internal/processors/cloud-vendor-aggregator/aws/services/s3/s3_test.go
+++ b/internal/processors/cloud-vendor-aggregator/aws/services/s3/s3_test.go
@@ -129,6 +129,7 @@ func TestGetData(t *testing.T) {
 				require.Equal(t, tc.expectedAsset.Location, asset.Location)
 				require.Equal(t, tc.expectedAsset.Provider, asset.Provider)
 				require.Equal(t, tc.expectedAsset.Tags, asset.Tags)
+				require.NotEmpty(t, asset.Timestamp)
 			}
 		})
 	}

--- a/internal/processors/cloud-vendor-aggregator/azure/services/functions/functions.go
+++ b/internal/processors/cloud-vendor-aggregator/azure/services/functions/functions.go
@@ -60,17 +60,13 @@ func (a *AzureFunction) GetData(_ context.Context, event *azureactivitylogeventh
 		}
 	}
 
-	asset := &commons.Asset{
-		Name:          *resource.Name,
-		Type:          *resource.Type,
-		Provider:      commons.AzureAssetProvider,
-		Location:      *resource.Location,
-		Tags:          tags,
-		Relationships: relationshipFromID(entity.(string)),
-		RawData:       data,
-	}
-
-	return json.Marshal(asset)
+	return json.Marshal(
+		commons.NewAsset(*resource.Name, *resource.Type, commons.AzureAssetProvider).
+			WithLocation(*resource.Location).
+			WithTags(tags).
+			WithRelationships(relationshipFromID(entity.(string))).
+			WithRawData(data),
+	)
 }
 
 func relationshipFromID(id string) []string {

--- a/internal/processors/cloud-vendor-aggregator/azure/services/storage/storage.go
+++ b/internal/processors/cloud-vendor-aggregator/azure/services/storage/storage.go
@@ -60,17 +60,13 @@ func (a *AzureStorage) GetData(_ context.Context, event *azureactivitylogeventhu
 		}
 	}
 
-	asset := &commons.Asset{
-		Name:          *resource.Name,
-		Type:          *resource.Type,
-		Provider:      commons.AzureAssetProvider,
-		Location:      *resource.Location,
-		Tags:          tags,
-		Relationships: relationshipFromID(entity.(string)),
-		RawData:       data,
-	}
-
-	return json.Marshal(asset)
+	return json.Marshal(
+		commons.NewAsset(*resource.Name, *resource.Type, commons.AzureAssetProvider).
+			WithLocation(*resource.Location).
+			WithTags(tags).
+			WithRelationships(relationshipFromID(entity.(string))).
+			WithRawData(data),
+	)
 }
 
 func relationshipFromID(id string) []string {

--- a/internal/processors/cloud-vendor-aggregator/commons/asset.go
+++ b/internal/processors/cloud-vendor-aggregator/commons/asset.go
@@ -15,6 +15,8 @@
 
 package commons
 
+import "time"
+
 const (
 	AWSAssetProvider   = "aws"
 	AzureAssetProvider = "azure"
@@ -24,11 +26,38 @@ const (
 type Tags map[string]string
 
 type Asset struct {
-	Name          string   `json:"name"`
-	Type          string   `json:"type"`
-	Provider      string   `json:"provider"`
-	Location      string   `json:"location"`
-	Relationships []string `json:"relationships"`
-	Tags          Tags     `json:"tags"`
-	RawData       []byte   `json:"rawData"`
+	Name          string    `json:"name"`
+	Type          string    `json:"type"`
+	Provider      string    `json:"provider"`
+	Location      string    `json:"location"`
+	Relationships []string  `json:"relationships"`
+	Tags          Tags      `json:"tags"`
+	RawData       []byte    `json:"rawData"`
+	Timestamp     time.Time `json:"timestamp"`
+}
+
+func NewAsset(name, assetType, provider string) *Asset {
+	return &Asset{
+		Name:      name,
+		Type:      assetType,
+		Provider:  provider,
+		Timestamp: time.Now(),
+	}
+}
+
+func (a *Asset) WithLocation(location string) *Asset {
+	a.Location = location
+	return a
+}
+func (a *Asset) WithRelationships(relationships []string) *Asset {
+	a.Relationships = relationships
+	return a
+}
+func (a *Asset) WithTags(tags Tags) *Asset {
+	a.Tags = tags
+	return a
+}
+func (a *Asset) WithRawData(rawData []byte) *Asset {
+	a.RawData = rawData
+	return a
 }

--- a/internal/processors/cloud-vendor-aggregator/gcp/services/service/service.go
+++ b/internal/processors/cloud-vendor-aggregator/gcp/services/service/service.go
@@ -67,17 +67,14 @@ func (g *GCPRunServiceDataAdapter) GetData(ctx context.Context, event *gcppubsub
 	}
 
 	name, location := nameAndLocationFromRunName(runServiceName)
-	asset := &commons.Asset{
-		Name:          name,
-		Type:          event.Asset.AssetType,
-		Provider:      commons.GCPAssetProvider,
-		Location:      location,
-		Tags:          service.Labels,
-		Relationships: event.Asset.Ancestors,
-		RawData:       data,
-	}
 
-	return json.Marshal(asset)
+	return json.Marshal(
+		commons.NewAsset(name, event.Asset.AssetType, commons.GCPAssetProvider).
+			WithLocation(location).
+			WithTags(service.Labels).
+			WithRelationships(event.Asset.Ancestors).
+			WithRawData(data),
+	)
 }
 
 func nameAndLocationFromRunName(runName string) (string, string) {

--- a/internal/processors/cloud-vendor-aggregator/gcp/services/storage/storage.go
+++ b/internal/processors/cloud-vendor-aggregator/gcp/services/storage/storage.go
@@ -47,15 +47,11 @@ func (g *GCPStorageDataAdapter) GetData(ctx context.Context, event *gcppubsubeve
 		return nil, err
 	}
 
-	asset := &commons.Asset{
-		Name:          bucket.Name,
-		Type:          event.Asset.AssetType,
-		Provider:      commons.GCPAssetProvider,
-		Location:      bucket.Location,
-		Tags:          bucket.Labels,
-		Relationships: event.Asset.Ancestors,
-		RawData:       data,
-	}
-
-	return json.Marshal(asset)
+	return json.Marshal(
+		commons.NewAsset(bucket.Name, StorageAssetType, commons.GCPAssetProvider).
+			WithLocation(bucket.Location).
+			WithTags(bucket.Labels).
+			WithRelationships(event.Asset.Ancestors).
+			WithRawData(data),
+	)
 }


### PR DESCRIPTION
include a standardized timestamp in all events processed by the cloud vendor aggregator processors, introduced an asset builder for such purpose.

Also for AWS events we are now skipping deletes similar to how it has been done for other cloud vendors.