### PR TITLE
fix: prevent panics for missing azure data

### DIFF
--- a/internal/processors/cloud-vendor-aggregator/azure/services/functions/functions.go
+++ b/internal/processors/cloud-vendor-aggregator/azure/services/functions/functions.go
@@ -53,17 +53,10 @@ func (a *AzureFunction) GetData(_ context.Context, event *azureactivitylogeventh
 		return nil, fmt.Errorf("failed to get resource by ID: %w", err)
 	}
 
-	tags := make(commons.Tags)
-	for key, value := range resource.Tags {
-		if value != nil {
-			tags[key] = *value
-		}
-	}
-
 	return json.Marshal(
-		commons.NewAsset(*resource.Name, *resource.Type, commons.AzureAssetProvider).
-			WithLocation(*resource.Location).
-			WithTags(tags).
+		commons.NewAsset(resource.Name, resource.Type, commons.AzureAssetProvider).
+			WithLocation(resource.Location).
+			WithTags(resource.Tags).
 			WithRelationships(relationshipFromID(entity.(string))).
 			WithRawData(data),
 	)

--- a/internal/processors/cloud-vendor-aggregator/azure/services/storage/storage.go
+++ b/internal/processors/cloud-vendor-aggregator/azure/services/storage/storage.go
@@ -53,17 +53,10 @@ func (a *AzureStorage) GetData(_ context.Context, event *azureactivitylogeventhu
 		return nil, fmt.Errorf("failed to get resource by ID: %w", err)
 	}
 
-	tags := make(commons.Tags)
-	for key, value := range resource.Tags {
-		if value != nil {
-			tags[key] = *value
-		}
-	}
-
 	return json.Marshal(
-		commons.NewAsset(*resource.Name, *resource.Type, commons.AzureAssetProvider).
-			WithLocation(*resource.Location).
-			WithTags(tags).
+		commons.NewAsset(resource.Name, resource.Type, commons.AzureAssetProvider).
+			WithLocation(resource.Location).
+			WithTags(resource.Tags).
 			WithRelationships(relationshipFromID(entity.(string))).
 			WithRawData(data),
 	)


### PR DESCRIPTION
Some Azure events may missing data (e.g. Location), since the original struct handls