### PR TITLE
fix: missing catalog lifecycle status + correct api paths

### DIFF
--- a/internal/sinks/console-catalog/config.go
+++ b/internal/sinks/console-catalog/config.go
@@ -21,22 +21,25 @@ import (
 	"net/url"
 
 	"github.com/mia-platform/integration-connector-agent/config"
+	"github.com/mia-platform/integration-connector-agent/internal/sinks/console-catalog/consoleclient"
 )
 
 var (
-	ErrURLNotSet    = errors.New("URL not set in CRUD service sink configuration")
-	ErrInvalidURL   = errors.New("invalid URL in CRUD service sink configuration")
-	ErrMissingField = errors.New("missing required field in CRUD service sink configuration")
+	ErrURLNotSet              = errors.New("URL not set in Console Catalog sink configuration")
+	ErrInvalidURL             = errors.New("invalid URL in Console Catalog sink configuration")
+	ErrInvalidLifecycleStatus = errors.New("invalid itemLifecycleStatus in Console Catalog sink configuration")
+	ErrMissingField           = errors.New("missing required field in Console Catalog sink configuration")
 )
 
 type Config struct {
-	URL              string              `json:"url"`
-	ItemType         string              `json:"itemType"`
-	TenantID         string              `json:"tenantId"`
-	ClientID         string              `json:"clientId"`
-	ClientSecret     config.SecretSource `json:"clientSecret"`
-	ItemIDTemplate   string              `json:"itemIdTemplate"`
-	ItemNameTemplate string              `json:"itemNameTemplate"`
+	URL                 string                        `json:"url"`
+	TenantID            string                        `json:"tenantId"`
+	ClientID            string                        `json:"clientId"`
+	ClientSecret        config.SecretSource           `json:"clientSecret"`
+	ItemType            string                        `json:"itemType"`
+	ItemLifecycleStatus consoleclient.LifecycleStatus `json:"itemLifecycleStatus"`
+	ItemIDTemplate      string                        `json:"itemIdTemplate"`
+	ItemNameTemplate    string                        `json:"itemNameTemplate"`
 }
 
 func (c *Config) Validate() error {
@@ -70,6 +73,14 @@ func (c *Config) Validate() error {
 
 	if c.ItemNameTemplate == "" {
 		return fmt.Errorf("%w: itemNameTemplate", ErrMissingField)
+	}
+
+	if c.ItemLifecycleStatus == "" {
+		c.ItemLifecycleStatus = consoleclient.Published
+	}
+
+	if !consoleclient.IsValidLifecycleStatus(string(c.ItemLifecycleStatus)) {
+		return fmt.Errorf("%w: %s", ErrInvalidLifecycleStatus, c.ItemLifecycleStatus)
 	}
 
 	return nil

--- a/internal/sinks/console-catalog/config_test.go
+++ b/internal/sinks/console-catalog/config_test.go
@@ -117,6 +117,20 @@ func TestConfigValidate(t *testing.T) {
 			expectedErr:          ErrMissingField,
 			expectedMissingField: "itemNameTemplate",
 		},
+		{
+			name: "invalid lifecycle status",
+			config: &Config{
+				URL:                 "http://example.com",
+				TenantID:            "tenant-id",
+				ItemType:            "item-type",
+				ClientID:            "client-id",
+				ClientSecret:        "client-secret",
+				ItemIDTemplate:      "item-id-template",
+				ItemNameTemplate:    "item-name-template",
+				ItemLifecycleStatus: "invalid-status",
+			},
+			expectedErr: ErrInvalidLifecycleStatus,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/sinks/console-catalog/consoleclient/catalog.go
+++ b/internal/sinks/console-catalog/consoleclient/catalog.go
@@ -42,7 +42,7 @@ func (c *consoleClient[T]) Apply(ctx context.Context, item *MarketplaceResource[
 		},
 	}
 
-	targetURL := fmt.Sprintf("%sapi/marketplace/tenants/%s/resources", c.url, item.TenantID)
+	targetURL := fmt.Sprintf("%sapi/tenants/%s/marketplace/items", c.url, item.TenantID)
 	resp, err := c.fireRequest(ctx, http.MethodPost, targetURL, marketplacePostExtension)
 	if err != nil {
 		return "", fmt.Errorf("error applying resource: %w", err)
@@ -72,7 +72,7 @@ func (c *consoleClient[T]) Apply(ctx context.Context, item *MarketplaceResource[
 }
 
 func (c *consoleClient[T]) Delete(ctx context.Context, tenantID string, itemID string) error {
-	targetURL := fmt.Sprintf("%sapi/marketplace/tenants/%s/resources/%s/versions/NA", c.url, tenantID, itemID)
+	targetURL := fmt.Sprintf("%sapi/tenants/%s/marketplace/items/%s/versions/NA", c.url, tenantID, itemID)
 	resp, err := c.fireRequest(ctx, http.MethodDelete, targetURL, nil)
 	if err != nil {
 		return fmt.Errorf("error deleting resource: %w", err)

--- a/internal/sinks/console-catalog/consoleclient/catalog_test.go
+++ b/internal/sinks/console-catalog/consoleclient/catalog_test.go
@@ -164,16 +164,17 @@ func TestCatalogApply(t *testing.T) {
 		}
 
 		item := MarketplaceResource[testResource]{
-			ItemID:   "myItem",
-			Name:     "myItemName",
-			TenantID: tenantID,
-			Type:     "resType",
+			ItemID:          "myItem",
+			Name:            "myItemName",
+			TenantID:        tenantID,
+			Type:            "resType",
+			LifecycleStatus: Draft,
 			Resources: testResource{
 				"k1": "v1",
 			},
 		}
 
-		expectedMarketplaceRequestBodyString := fmt.Sprintf("{\"resources\":[{\"description\":\"\",\"itemId\":\"myItem\",\"name\":\"myItemName\",\"resources\":{\"k1\":\"v1\"},\"tenantId\":\"%s\",\"type\":\"resType\"}]}", tenantID)
+		expectedMarketplaceRequestBodyString := fmt.Sprintf("{\"resources\":[{\"description\":\"\",\"itemId\":\"myItem\",\"lifecycleStatus\":\"draft\",\"name\":\"myItemName\",\"resources\":{\"k1\":\"v1\"},\"tenantId\":\"%s\",\"type\":\"resType\"}]}", tenantID)
 
 		m := runMocha(t, marketplaceBaseURL)
 		m = registerAPI(t, m,
@@ -269,15 +270,16 @@ func TestCatalogApply(t *testing.T) {
 		}
 
 		item1 := MarketplaceResource[testResource]{
-			ItemID:   "myItem",
-			Name:     "myItemName",
-			TenantID: tenantID,
-			Type:     "resType",
+			ItemID:          "myItem",
+			Name:            "myItemName",
+			TenantID:        tenantID,
+			Type:            "resType",
+			LifecycleStatus: Published,
 			Resources: testResource{
 				"k1": "v1",
 			},
 		}
-		expectedMarketplaceRequestBodyString1 := fmt.Sprintf("{\"resources\":[{\"description\":\"\",\"itemId\":\"myItem\",\"name\":\"myItemName\",\"resources\":{\"k1\":\"v1\"},\"tenantId\":\"%s\",\"type\":\"resType\"}]}", tenantID)
+		expectedMarketplaceRequestBodyString1 := fmt.Sprintf("{\"resources\":[{\"description\":\"\",\"itemId\":\"myItem\",\"lifecycleStatus\":\"published\",\"name\":\"myItemName\",\"resources\":{\"k1\":\"v1\"},\"tenantId\":\"%s\",\"type\":\"resType\"}]}", tenantID)
 
 		m := runMocha(t, marketplaceBaseURL)
 		m = registerAPI(t, m,

--- a/internal/sinks/console-catalog/consoleclient/catalog_test.go
+++ b/internal/sinks/console-catalog/consoleclient/catalog_test.go
@@ -31,7 +31,7 @@ func TestCatalogApply(t *testing.T) {
 	const marketplaceBaseURL = "127.0.0.1:45874"
 	const tenantID = "tenant123"
 
-	applyPath := fmt.Sprintf("/api/marketplace/tenants/%s/resources", tenantID)
+	applyPath := fmt.Sprintf("/api/tenants/%s/marketplace/items", tenantID)
 
 	client := New[testResource](fmt.Sprintf("http://%s/", marketplaceBaseURL), &mockedTokenManager{})
 	item := MarketplaceResource[testResource]{
@@ -337,7 +337,7 @@ func TestCatalogDelete(t *testing.T) {
 	const tenantID = "tenant123"
 	const itemID = "item123"
 
-	deletePath := fmt.Sprintf("/api/marketplace/tenants/%s/resources/%s/versions/NA", tenantID, itemID)
+	deletePath := fmt.Sprintf("/api/tenants/%s/marketplace/items/%s/versions/NA", tenantID, itemID)
 
 	client := New[testResource](fmt.Sprintf("http://%s/", marketplaceBaseURL), &mockedTokenManager{})
 

--- a/internal/sinks/console-catalog/consoleclient/interface.go
+++ b/internal/sinks/console-catalog/consoleclient/interface.go
@@ -29,6 +29,25 @@ var (
 	ErrMarketplaceRequestBodyParse = errors.New("failed to prepare marketplace request")
 )
 
+type LifecycleStatus string
+
+const (
+	ComingSoon  LifecycleStatus = "coming-soon"
+	Draft       LifecycleStatus = "draft"
+	Published   LifecycleStatus = "published"
+	Maintenance LifecycleStatus = "maintenance"
+	Deprecated  LifecycleStatus = "deprecated"
+	Archived    LifecycleStatus = "archived"
+)
+
+func IsValidLifecycleStatus(status string) bool {
+	switch LifecycleStatus(status) {
+	case ComingSoon, Draft, Published, Maintenance, Deprecated, Archived:
+		return true
+	}
+	return false
+}
+
 type Resource any
 
 type CatalogClient[T Resource] interface {
@@ -37,13 +56,14 @@ type CatalogClient[T Resource] interface {
 }
 
 type MarketplaceResource[T Resource] struct {
-	ID          string `json:"_id,omitempty"` //nolint:tagliatelle
-	ItemID      string `json:"itemId"`
-	Name        string `json:"name"`
-	Type        string `json:"type"`
-	Description string `json:"description"`
-	TenantID    string `json:"tenantId"`
-	Resources   T      `json:"resources"`
+	ID              string          `json:"_id,omitempty"` //nolint:tagliatelle
+	ItemID          string          `json:"itemId"`
+	Name            string          `json:"name"`
+	Type            string          `json:"type"`
+	Description     string          `json:"description"`
+	TenantID        string          `json:"tenantId"`
+	LifecycleStatus LifecycleStatus `json:"lifecycleStatus"`
+	Resources       T               `json:"resources"`
 }
 
 type ValidationError struct {

--- a/internal/sinks/console-catalog/writer.go
+++ b/internal/sinks/console-catalog/writer.go
@@ -76,11 +76,12 @@ func (w *Writer[T]) createCatalogItem(event T) (*consoleclient.MarketplaceResour
 	}
 
 	return &consoleclient.MarketplaceResource[any]{
-		TenantID:  w.config.TenantID,
-		Name:      itemName,
-		ItemID:    slugify(itemID),
-		Type:      w.config.ItemType,
-		Resources: res,
+		TenantID:        w.config.TenantID,
+		Name:            itemName,
+		ItemID:          slugify(itemID),
+		Type:            w.config.ItemType,
+		LifecycleStatus: w.config.ItemLifecycleStatus,
+		Resources:       res,
 	}, nil
 }
 


### PR DESCRIPTION
This PR fixes the API paths used to interact with the Mia-Platform catalog