### PR TITLE
feat: catalog sink generates itemId from event PKs

### DIFF
--- a/docs/sinks/15_console-catalog.md
+++ b/docs/sinks/15_console-catalog.md
@@ -18,7 +18,7 @@ To configure the Console Catalog sink, you need to provide the following paramet
 - `itemType` (*string*): The type of the generated catalog item.
 - `clientId` (*string*): The client ID to use for authentication with the Console Catalog API.
 - `clientSecret` ([*SecretSource*](../20_install.md#secretsource)): The client secret to use for authentication with the Console Catalog API.
-- `itemIDTemplate` (*string*): A [template](#template-processing) used to generate the item ID for the catalog item.
+- `itemIDTemplate` (*string*, optional): A [template](#template-processing) used to generate the item ID for the catalog item. When not provided the itemId is derived from the event Primary Keys.
 - `itemNameTemplate` (*string*): A [template](#template-processing) used to generate the name for the catalog item.
 
 ### Example Configuration

--- a/internal/sinks/console-catalog/config.go
+++ b/internal/sinks/console-catalog/config.go
@@ -67,10 +67,6 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("%w: clientSecret", ErrMissingField)
 	}
 
-	if c.ItemIDTemplate == "" {
-		return fmt.Errorf("%w: itemIdTemplate", ErrMissingField)
-	}
-
 	if c.ItemNameTemplate == "" {
 		return fmt.Errorf("%w: itemNameTemplate", ErrMissingField)
 	}

--- a/internal/sinks/console-catalog/config_test.go
+++ b/internal/sinks/console-catalog/config_test.go
@@ -93,7 +93,7 @@ func TestConfigValidate(t *testing.T) {
 			expectedMissingField: "clientSecret",
 		},
 		{
-			name: "missing item ID template",
+			name: "configuration is valid even when missing item ID template",
 			config: &Config{
 				URL:              "http://example.com",
 				TenantID:         "tenant-id",

--- a/internal/sinks/console-catalog/config_test.go
+++ b/internal/sinks/console-catalog/config_test.go
@@ -95,14 +95,13 @@ func TestConfigValidate(t *testing.T) {
 		{
 			name: "missing item ID template",
 			config: &Config{
-				URL:          "http://example.com",
-				TenantID:     "tenant-id",
-				ItemType:     "item-type",
-				ClientID:     "client-id",
-				ClientSecret: "client-secret",
+				URL:              "http://example.com",
+				TenantID:         "tenant-id",
+				ItemType:         "item-type",
+				ClientID:         "client-id",
+				ClientSecret:     "client-secret",
+				ItemNameTemplate: "item-name-template",
 			},
-			expectedErr:          ErrMissingField,
-			expectedMissingField: "itemIdTemplate",
 		},
 		{
 			name: "missing item name template",

--- a/internal/sinks/console-catalog/writer.go
+++ b/internal/sinks/console-catalog/writer.go
@@ -88,15 +88,15 @@ func (w *Writer[T]) createCatalogItem(event T) (*consoleclient.MarketplaceResour
 
 func (w *Writer[T]) getItemID(event T) (string, error) {
 	if w.config.ItemIDTemplate == "" {
-		var itemIdBuilder strings.Builder
+		var itemIDBuilder strings.Builder
 		pks := event.GetPrimaryKeys()
 		for i, pk := range pks {
-			fmt.Fprintf(&itemIdBuilder, "%s-%s", slugify(pk.Key), slugify(pk.Value))
+			fmt.Fprintf(&itemIDBuilder, "%s-%s", slugify(pk.Key), slugify(pk.Value))
 			if i != len(pks)-1 {
-				itemIdBuilder.WriteString("-")
+				itemIDBuilder.WriteString("-")
 			}
 		}
-		return itemIdBuilder.String(), nil
+		return itemIDBuilder.String(), nil
 	}
 
 	itemID, err := templetize(w.config.ItemIDTemplate, event.Data())


### PR DESCRIPTION
This PR allows the Console Catalog Sink to use event primary keys to generate the itemid. The itemIdTemplate config is still available to override this behavior with a customized itemId.