### PR TITLE
fix: azure resource deletion

### DIFF
--- a/internal/processors/cloud-vendor-aggregator/azure/processor.go
+++ b/internal/processors/cloud-vendor-aggregator/azure/processor.go
@@ -53,11 +53,6 @@ func New(logger *logrus.Logger, authOptions config.AuthOptions) (*Processor, err
 func (p *Processor) Process(input entities.PipelineEvent) (entities.PipelineEvent, error) {
 	output := input.Clone()
 
-	if input.Operation() == entities.Delete {
-		p.logger.Debug("Delete operation detected, skipping processing")
-		return output, nil
-	}
-
 	if input.GetType() == azure.EventTypeFromLiveLoad.String() {
 		newData, err := p.GetDataFromLiveEvent(input)
 		if err != nil {
@@ -82,6 +77,11 @@ func (p *Processor) Process(input entities.PipelineEvent) (entities.PipelineEven
 			}).
 			Debug("Event discarded for result type")
 		return nil, entities.ErrDiscardEvent
+	}
+
+	if input.Operation() == entities.Delete {
+		p.logger.Debug("Delete operation detected, skipping processing")
+		return output, nil
 	}
 
 	adapter, err := p.EventDataProcessor(activityLogEvent)

--- a/internal/processors/cloud-vendor-aggregator/azure/processor_test.go
+++ b/internal/processors/cloud-vendor-aggregator/azure/processor_test.go
@@ -190,6 +190,34 @@ func TestProcessor(t *testing.T) {
 				}).
 				WithRawData([]byte(liveData)),
 		},
+		"delete operation in success state": {
+			input: &entities.Event{
+				PrimaryKeys: entities.PkFields{
+					{
+						Key:   "resourceId",
+						Value: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group/providers/Microsoft.Storage/storageAccounts/account",
+					},
+				},
+				Type:          azure.EventTypeRecordFromEventHub.String(),
+				OperationType: entities.Delete,
+				OriginalRaw:   []byte(deleteSuccededActivity),
+			},
+			expectedAsset: commons.NewAsset("", "", ""),
+		},
+		"delete operation in started state": {
+			input: &entities.Event{
+				PrimaryKeys: entities.PkFields{
+					{
+						Key:   "resourceId",
+						Value: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group/providers/Microsoft.Storage/storageAccounts/account",
+					},
+				},
+				Type:          azure.EventTypeRecordFromEventHub.String(),
+				OperationType: entities.Delete,
+				OriginalRaw:   []byte(deleteStartedActivity),
+			},
+			expectedError: entities.ErrDiscardEvent,
+		},
 		"filter activity log not in success state": {
 			input: &entities.Event{
 				PrimaryKeys: entities.PkFields{
@@ -366,6 +394,66 @@ const functionActivityLog = `{
 		"eventCategory": "Administrative",
 		"entity": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group/providers/Microsoft.Web/sites/function",
 		"message": "Microsoft.Web/sites/write",
+		"hierarchy": "00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000"
+	},
+	"tenantId": "00000000-0000-0000-0000-000000000000"
+}`
+
+const deleteSuccededActivity = `{
+	"resourceId": "/SUBSCRIPTIONS/00000000-0000-0000-0000-000000000000/RESOURCEGROUPS/GROUP/PROVIDERS/MICROSOFT.WEB/SITES/FUNCTION",
+	"operationName": "MICROSOFT.WEB/SITES/DELETE",
+	"category": "Administrative",
+	"resultType": "Succeeded",
+	"resultSignature": "Succeeded.",
+	"identity": {
+		"authorization": {
+			"scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group/providers/Microsoft.Web/sites/function",
+			"action": "Microsoft.Web/sites/delete",
+			"evidence": {
+				"role": "Contributor",
+				"roleAssignmentScope": "/subscriptions/00000000-0000-0000-0000-000000000000",
+				"roleAssignmentId": "00000000000000000000000000000000",
+				"roleDefinitionId": "00000000000000000000000000000000",
+				"principalId": "00000000000000000000000000000000",
+				"principalType": "ServicePrincipal"
+			}
+		}
+	},
+	"level": "Information",
+	"properties": {
+		"eventCategory": "Administrative",
+		"entity": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group/providers/Microsoft.Web/sites/function",
+		"message": "Microsoft.Web/sites/delete",
+		"hierarchy": "00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000"
+	},
+	"tenantId": "00000000-0000-0000-0000-000000000000"
+}`
+
+const deleteStartedActivity = `{
+	"resourceId": "/SUBSCRIPTIONS/00000000-0000-0000-0000-000000000000/RESOURCEGROUPS/GROUP/PROVIDERS/MICROSOFT.WEB/SITES/FUNCTION",
+	"operationName": "MICROSOFT.WEB/SITES/DELETE",
+	"category": "Administrative",
+	"resultType": "Started",
+	"resultSignature": "Started.",
+	"identity": {
+		"authorization": {
+			"scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group/providers/Microsoft.Web/sites/function",
+			"action": "Microsoft.Web/sites/delete",
+			"evidence": {
+				"role": "Contributor",
+				"roleAssignmentScope": "/subscriptions/00000000-0000-0000-0000-000000000000",
+				"roleAssignmentId": "00000000000000000000000000000000",
+				"roleDefinitionId": "00000000000000000000000000000000",
+				"principalId": "00000000000000000000000000000000",
+				"principalType": "ServicePrincipal"
+			}
+		}
+	},
+	"level": "Information",
+	"properties": {
+		"eventCategory": "Administrative",
+		"entity": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group/providers/Microsoft.Web/sites/function",
+		"message": "Microsoft.Web/sites/delete",
 		"hierarchy": "00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000"
 	},
 	"tenantId": "00000000-0000-0000-0000-000000000000"


### PR DESCRIPTION
<!-- Hi, and thank you for your time dedicated to this pull request! Please provide a description
of the work you have done and be sure to link to the relative open issue if is present.

Be aware that all the work you have done should include also the relative tests to assure the
correct behavior and avoid possible regressions in the future.
-->

## What this PR is for?

This PR will fix a bug in the Azure resource deletion flow. Now it will forward the deletion event only if its state is "Success" or "Succeeded".

<!--
Describe what this PR is trying to achieve, for example is this a PR that fix an open issue? Is for a new feature? etc.
-->

**Which issue(s) this PR fixes:**
<!--
Link any associated issues with this PR for automatically close them when the PR is merged. You can reference them
with only `#<issue number>` or via the full link to the issue.
-->
- Fixes #
