### PR TITLE
Add type casting to mapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+- Add string and number cast feature in the mapper
+
 ### Chaged
 
 - update go to v1.25.3

--- a/docs/processors/20_mapper.md
+++ b/docs/processors/20_mapper.md
@@ -54,6 +54,87 @@ It is also possible to set static data, for example:
 
 In this case, the `key` field will always have the value `static-value`.
 
+### Type Casting
+
+The Mapper processor supports type casting to ensure that field values are stored in the correct data type. 
+This is particularly useful when working with databases like MongoDB that don't enforce type constraints.
+
+To cast a field value, use an object with `value` and `castTo` properties instead of a simple template string:
+
+```json
+{
+  "type": "mapper",
+  "outputEvent": {
+    "key": "{{ issue.key }}",
+    "issueId": {
+      "value": "{{ issue.id }}",
+      "castTo": "string"
+    },
+    "priority": {
+      "value": "{{ issue.fields.priority }}",
+      "castTo": "number"
+    }
+  }
+}
+```
+
+#### Supported Cast Types
+
+- **`string`**: Converts any value to its string representation
+- **`number`**: Converts strings, integers, and booleans to numbers (float64)
+  - Booleans: `true` becomes `1`, `false` becomes `0`
+  - Strings: Must be valid numeric strings, otherwise an error is thrown
+
+#### Error Handling
+
+If a cast operation fails (e.g., trying to cast "not-a-number" to a number), the processor will return an error 
+and the event will not be saved to the sink. This ensures data integrity.
+
+#### Example with Casting
+
+Given an input event where numeric IDs are sent as numbers but need to be stored as strings:
+
+```json
+{
+  "issue": {
+    "id": 155331,
+    "key": "ISSUE-123",
+    "fields": {
+      "priority": "3"
+    }
+  }
+}
+```
+
+With this configuration:
+
+```json
+{
+  "type": "mapper",
+  "outputEvent": {
+    "key": "{{ issue.key }}",
+    "issueId": {
+      "value": "{{ issue.id }}",
+      "castTo": "string"
+    },
+    "priority": {
+      "value": "{{ issue.fields.priority }}",
+      "castTo": "number"
+    }
+  }
+}
+```
+
+The output will be:
+
+```json
+{
+  "key": "ISSUE-123",
+  "issueId": "155331",
+  "priority": 3
+}
+```
+
 ### Limitation
 
 It is not possible combine multiple fields in a single output field.

--- a/examples/mapper-casting-config.json
+++ b/examples/mapper-casting-config.json
@@ -1,0 +1,31 @@
+{
+  "type": "mapper",
+  "outputEvent": {
+    "key": "{{ issue.key }}",
+    "issueId": {
+      "value": "{{ issue.id }}",
+      "castTo": "string"
+    },
+    "issueLinkId": {
+      "value": "{{ issueLink.id }}",
+      "castTo": "string"
+    },
+    "sourceIssueId": {
+      "value": "{{ issueLink.sourceIssueId }}",
+      "castTo": "string"
+    },
+    "destinationIssueId": {
+      "value": "{{ issueLink.destinationIssueId }}",
+      "castTo": "string"
+    },
+    "linkTypeId": {
+      "value": "{{ issueLink.issueLinkType.id }}",
+      "castTo": "number"
+    },
+    "linkTypeName": "{{ issueLink.issueLinkType.name }}",
+    "createdAt": {
+      "value": "{{ issue.fields.created }}",
+      "castTo": "string"
+    }
+  }
+}

--- a/internal/processors/mapper/mapper.go
+++ b/internal/processors/mapper/mapper.go
@@ -83,7 +83,10 @@ func generateOperations(jsonData gjson.Result) ([]operation, error) {
 				keyToUpdate = strings.Join([]string{keyPrefix, key.String()}, ".")
 			}
 
-			if value.IsObject() || value.IsArray() {
+			// Check if this is a casting configuration object
+			isCastConfig := value.IsObject() && value.Get("value").Exists() && value.Get("castTo").Exists()
+
+			if !isCastConfig && (value.IsObject() || value.IsArray()) {
 				walk(value, keyToUpdate)
 				return true
 			}

--- a/internal/processors/mapper/mapper.go
+++ b/internal/processors/mapper/mapper.go
@@ -83,7 +83,6 @@ func generateOperations(jsonData gjson.Result) ([]operation, error) {
 				keyToUpdate = strings.Join([]string{keyPrefix, key.String()}, ".")
 			}
 
-			// Check if this is a casting configuration object
 			isCastConfig := value.IsObject() && value.Get("value").Exists() && value.Get("castTo").Exists()
 
 			if !isCastConfig && (value.IsObject() || value.IsArray()) {

--- a/internal/processors/mapper/operation.go
+++ b/internal/processors/mapper/operation.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strconv"
 
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -17,6 +18,7 @@ import (
 var (
 	errTransform = errors.New("error transforming data")
 	errOperation = errors.New("error creating operation")
+	errCast      = errors.New("error casting value")
 )
 
 var dynamicOperatorRegexp = regexp.MustCompile(`{{\s*(.*?)\s*}}`)
@@ -27,11 +29,20 @@ const (
 	set operationType = iota
 )
 
+type castType string
+
+const (
+	castToString castType = "string"
+	castToNumber castType = "number"
+	castToNone   castType = ""
+)
+
 type operation struct {
 	keyToUpdate   string
 	valueKeys     []string
 	operationType operationType
 	templateValue any
+	castTo        castType
 }
 
 func (o operation) getValueToSet(input []byte) any {
@@ -41,6 +52,41 @@ func (o operation) getValueToSet(input []byte) any {
 	key := o.valueKeys[0]
 	value := gjson.GetBytes(input, key)
 	return value.Value()
+}
+
+func (o operation) castValue(value any) (any, error) {
+	if o.castTo == castToNone {
+		return value, nil
+	}
+
+	switch o.castTo {
+	case castToString:
+		return fmt.Sprintf("%v", value), nil
+	case castToNumber:
+		switch v := value.(type) {
+		case float64:
+			return v, nil
+		case int:
+			return float64(v), nil
+		case int64:
+			return float64(v), nil
+		case string:
+			num, err := strconv.ParseFloat(v, 64)
+			if err != nil {
+				return nil, fmt.Errorf("%w: cannot cast string '%s' to number: %w", errCast, v, err)
+			}
+			return num, nil
+		case bool:
+			if v {
+				return float64(1), nil
+			}
+			return float64(0), nil
+		default:
+			return nil, fmt.Errorf("%w: cannot cast type %T to number", errCast, value)
+		}
+	default:
+		return nil, fmt.Errorf("%w: unsupported cast type: %s", errCast, o.castTo)
+	}
 }
 
 func (o operation) apply(input, output []byte) ([]byte, error) {
@@ -65,7 +111,18 @@ func (o operation) setData(input, output []byte) ([]byte, error) {
 		return nil, fmt.Errorf("%w: output key is empty", errTransform)
 	}
 
-	out, err := sjson.SetBytes(output, o.keyToUpdate, o.getValueToSet(input))
+	valueToSet := o.getValueToSet(input)
+	
+	// Apply casting if configured
+	if o.castTo != castToNone {
+		castedValue, err := o.castValue(valueToSet)
+		if err != nil {
+			return nil, fmt.Errorf("%w: failed to cast value for key '%s': %w", errTransform, o.keyToUpdate, err)
+		}
+		valueToSet = castedValue
+	}
+
+	out, err := sjson.SetBytes(output, o.keyToUpdate, valueToSet)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", errTransform, err)
 	}
@@ -77,9 +134,36 @@ func (o operation) setData(input, output []byte) ([]byte, error) {
 // keyToUpdate are the keys where to retrieve the value from the input JSON.
 // outputValue is the key where to set the value in the output JSON.
 func newOperation(keyToUpdate string, template gjson.Result) (operation, error) {
-	matches := dynamicOperatorRegexp.FindAllStringSubmatch(template.String(), -1)
+	var templateValue gjson.Result
+	var castTo castType
+
+	// Check if template is an object with "value" and "castTo" fields
+	if template.IsObject() {
+		valueField := template.Get("value")
+		castToField := template.Get("castTo")
+		
+		if valueField.Exists() && castToField.Exists() {
+			// Extract the castTo value
+			castToStr := castToField.String()
+			if castToStr != "" {
+				// Validate castTo value
+				if castToStr != string(castToString) && castToStr != string(castToNumber) {
+					return operation{}, fmt.Errorf("%w: invalid castTo value '%s', must be 'string' or 'number'", errOperation, castToStr)
+				}
+				castTo = castType(castToStr)
+			}
+			templateValue = valueField
+		} else {
+			// If it's an object but doesn't have the value/castTo structure, treat it as a regular template
+			templateValue = template
+		}
+	} else {
+		templateValue = template
+	}
+
+	matches := dynamicOperatorRegexp.FindAllStringSubmatch(templateValue.String(), -1)
 	if len(matches) > 1 {
-		return operation{}, fmt.Errorf("%w: unsupported combine template: %s", errOperation, template)
+		return operation{}, fmt.Errorf("%w: unsupported combine template: %s", errOperation, templateValue)
 	}
 
 	var valueKeys []string
@@ -91,6 +175,7 @@ func newOperation(keyToUpdate string, template gjson.Result) (operation, error) 
 		valueKeys:     valueKeys,
 		keyToUpdate:   keyToUpdate,
 		operationType: set,
-		templateValue: template.Value(),
+		templateValue: templateValue.Value(),
+		castTo:        castTo,
 	}, nil
 }

--- a/internal/processors/mapper/operation.go
+++ b/internal/processors/mapper/operation.go
@@ -112,8 +112,7 @@ func (o operation) setData(input, output []byte) ([]byte, error) {
 	}
 
 	valueToSet := o.getValueToSet(input)
-	
-	// Apply casting if configured
+
 	if o.castTo != castToNone {
 		castedValue, err := o.castValue(valueToSet)
 		if err != nil {
@@ -141,12 +140,10 @@ func newOperation(keyToUpdate string, template gjson.Result) (operation, error) 
 	if template.IsObject() {
 		valueField := template.Get("value")
 		castToField := template.Get("castTo")
-		
+
 		if valueField.Exists() && castToField.Exists() {
-			// Extract the castTo value
 			castToStr := castToField.String()
 			if castToStr != "" {
-				// Validate castTo value
 				if castToStr != string(castToString) && castToStr != string(castToNumber) {
 					return operation{}, fmt.Errorf("%w: invalid castTo value '%s', must be 'string' or 'number'", errOperation, castToStr)
 				}
@@ -154,7 +151,8 @@ func newOperation(keyToUpdate string, template gjson.Result) (operation, error) 
 			}
 			templateValue = valueField
 		} else {
-			// If it's an object but doesn't have the value/castTo structure, treat it as a regular template
+			// If it's an object but doesn't have the value/castTo structure,
+			// treat it as a regular template
 			templateValue = template
 		}
 	} else {


### PR DESCRIPTION
## What this PR is for?

This PR implements type casting functionality in the mapper processor as requested in the issue. The feature allows fields to be cast to specific types (string or number) during the mapping process, ensuring data type consistency before saving to the database.

**Which issue(s) this PR is realted to:**
- Implement #104 
